### PR TITLE
feat: add initial transform API

### DIFF
--- a/sketch/src/sketch.gleam
+++ b/sketch/src/sketch.gleam
@@ -11,6 +11,7 @@ import sketch/internals/cache/setup as cache
 import sketch/internals/style
 import sketch/media.{type Query}
 import sketch/size.{type Size}
+import sketch/transform.{type Transform}
 
 // Types
 
@@ -1983,8 +1984,8 @@ pub fn touch_action(value: String) {
   property("touch-action", value)
 }
 
-pub fn transform(transform: String) {
-  property("transform", transform)
+pub fn transform(transform: Transform) {
+  property("transform", transform.to_string(transform))
 }
 
 pub fn transform_box(transform_box: String) {

--- a/sketch/src/sketch.gleam
+++ b/sketch/src/sketch.gleam
@@ -11,7 +11,6 @@ import sketch/internals/cache/setup as cache
 import sketch/internals/style
 import sketch/media.{type Query}
 import sketch/size.{type Size}
-import sketch/transform.{type Transform}
 
 // Types
 
@@ -1984,8 +1983,8 @@ pub fn touch_action(value: String) {
   property("touch-action", value)
 }
 
-pub fn transform(transform: Transform) {
-  property("transform", transform.to_string(transform))
+pub fn transform(transform: String) {
+  property("transform", transform)
 }
 
 pub fn transform_box(transform_box: String) {

--- a/sketch/src/sketch.gleam
+++ b/sketch/src/sketch.gleam
@@ -11,6 +11,7 @@ import sketch/internals/cache/setup as cache
 import sketch/internals/style
 import sketch/media.{type Query}
 import sketch/size.{type Size}
+import sketch/transform.{type Transform}
 
 // Types
 
@@ -1983,8 +1984,15 @@ pub fn touch_action(value: String) {
   property("touch-action", value)
 }
 
+/// `transform` will be turned into `transform_` in 4.0.0
 pub fn transform(transform: String) {
   property("transform", transform)
+}
+
+/// `transform_` uses `sketch.transform` to offer an enhanced API for CSS transforms
+pub fn transform_(transform_args: List(Transform)) {
+  let transform_string = transform.to_string(transform_args)
+  property("transform", transform_string)
 }
 
 pub fn transform_box(transform_box: String) {

--- a/sketch/src/sketch/angle.gleam
+++ b/sketch/src/sketch/angle.gleam
@@ -1,0 +1,33 @@
+import gleam/float
+
+pub opaque type Angle {
+  Deg(Float)
+  Rad(Float)
+  Grad(Float)
+  Turn(Float)
+}
+
+pub fn deg(value: Float) {
+  Deg(value)
+}
+
+pub fn rad(value: Float) {
+  Rad(value)
+}
+
+pub fn grad(value: Float) {
+  Grad(value)
+}
+
+pub fn turn(value: Float) {
+  Turn(value)
+}
+
+pub fn to_string(angle: Angle) {
+  case angle {
+    Deg(value) -> float.to_string(value) <> "deg"
+    Rad(value) -> float.to_string(value) <> "rad"
+    Grad(value) -> float.to_string(value) <> "grad"
+    Turn(value) -> float.to_string(value) <> "turn"
+  }
+}

--- a/sketch/src/sketch/transform.gleam
+++ b/sketch/src/sketch/transform.gleam
@@ -11,54 +11,43 @@ pub opaque type Transform {
 }
 
 pub opaque type TransformFunction {
-  Translate(Size, Option(Size))
+  Translate(Size, Size)
   TranslateX(Size)
   TranslateY(Size)
-  Scale(Float, Option(Float))
+  Scale(Float, Float)
   ScaleX(Float)
   ScaleY(Float)
   Rotate(Angle)
-  Skew(Angle, Option(Angle))
   SkewX(Angle)
   SkewY(Angle)
 }
 
 fn transform_function_to_string(value: TransformFunction) {
   case value {
-    Translate(x, option.None) ->
-      "translate("
-      <> string.join([size.to_string(x), size.to_string(x)], ",")
-      <> ")"
-    Translate(x, option.Some(y)) ->
+    Translate(x, y) ->
       "translate("
       <> string.join([size.to_string(x), size.to_string(y)], ",")
       <> ")"
     TranslateX(x) -> "translateX(" <> size.to_string(x) <> ")"
     TranslateY(y) -> "translateY(" <> size.to_string(y) <> ")"
-    Scale(x, option.None) ->
-      "scale("
-      <> string.join([float.to_string(x), float.to_string(x)], ",")
-      <> ")"
-    Scale(x, option.Some(y)) ->
+    Scale(x, y) ->
       "scale("
       <> string.join([float.to_string(x), float.to_string(y)], ",")
       <> ")"
     ScaleX(x) -> "scaleX(" <> float.to_string(x) <> ")"
     ScaleY(y) -> "scaleY(" <> float.to_string(y) <> ")"
     Rotate(ang) -> "rotate(" <> angle.to_string(ang) <> ")"
-    Skew(x, option.None) ->
-      "translate(" <> string.join([angle.to_string(x), "0"], ",") <> ")"
-    Skew(x, option.Some(y)) ->
-      "translate("
-      <> string.join([angle.to_string(x), angle.to_string(y)], ",")
-      <> ")"
     SkewX(x) -> "skewX(" <> angle.to_string(x) <> ")"
     SkewY(y) -> "skewY(" <> angle.to_string(y) <> ")"
   }
 }
 
-pub fn translate(x: Size, y: Option(Size)) {
+pub fn translate2(x: Size, y: Size) {
   Translate(x, y)
+}
+
+pub fn translate(x: Size) {
+  translate2(x, size.percent(0))
 }
 
 pub fn translate_x(x: Size) {
@@ -69,8 +58,12 @@ pub fn translate_y(y: Size) {
   TranslateY(y)
 }
 
-pub fn scale(x: Float, y: Option(Float)) {
+pub fn scale2(x: Float, y: Float) {
   Scale(x, y)
+}
+
+pub fn scale(x: Float, ) {
+  Scale(x, x)
 }
 
 pub fn scale_x(x: Float) {
@@ -81,16 +74,20 @@ pub fn scale_y(y: Float) {
   ScaleY(y)
 }
 
-pub fn skew(x: Angle, y: Option(Angle)) {
-  Skew(x, y)
-}
-
 pub fn skew_x(x: Angle) {
   SkewX(x)
 }
 
 pub fn skew_y(x: Angle) {
   SkewY(x)
+}
+
+pub fn none() {
+	None
+}
+
+pub fn list(values: List(TransformFunction)) {
+  TransformList(values)
 }
 
 pub fn to_string(value: Transform) {

--- a/sketch/src/sketch/transform.gleam
+++ b/sketch/src/sketch/transform.gleam
@@ -1,16 +1,10 @@
 import gleam/float
 import gleam/list
-import gleam/option.{type Option}
 import gleam/string
 import sketch/angle.{type Angle}
 import sketch/size.{type Size}
 
 pub opaque type Transform {
-  None
-  TransformList(List(TransformFunction))
-}
-
-pub opaque type TransformFunction {
   Translate(Size, Size)
   TranslateX(Size)
   TranslateY(Size)
@@ -22,7 +16,7 @@ pub opaque type TransformFunction {
   SkewY(Angle)
 }
 
-fn transform_function_to_string(value: TransformFunction) {
+fn transform_to_string(value: Transform) {
   case value {
     Translate(x, y) ->
       "translate("
@@ -46,7 +40,7 @@ pub fn translate2(x: Size, y: Size) {
   Translate(x, y)
 }
 
-/// translate(x) is translate2(x, size.percent(0))
+/// `translate(x)` is `translate2(x, size.percent(0))`
 pub fn translate(x: Size) {
   translate2(x, size.percent(0))
 }
@@ -63,7 +57,7 @@ pub fn scale2(x: Float, y: Float) {
   Scale(x, y)
 }
 
-/// scale(x) is scale2(x, x)
+/// `scale(x)` is `scale2(x, x)`
 pub fn scale(x: Float) {
   scale2(x, x)
 }
@@ -88,19 +82,11 @@ pub fn skew_y(x: Angle) {
   SkewY(x)
 }
 
-pub fn none() {
-  None
-}
-
-pub fn list(values: List(TransformFunction)) {
-  TransformList(values)
-}
-
-pub fn to_string(value: Transform) {
+pub fn to_string(value: List(Transform)) {
   let content = case value {
-    None -> "none"
-    TransformList(transform_list) ->
-      list.map(transform_list, transform_function_to_string) |> string.join(" ")
+    [] -> "none"
+    transform_list ->
+      list.map(transform_list, transform_to_string) |> string.join(" ")
   }
 
   "transform: " <> content

--- a/sketch/src/sketch/transform.gleam
+++ b/sketch/src/sketch/transform.gleam
@@ -83,11 +83,9 @@ pub fn skew_y(x: Angle) {
 }
 
 pub fn to_string(value: List(Transform)) {
-  let content = case value {
+  case value {
     [] -> "none"
     transform_list ->
       list.map(transform_list, transform_to_string) |> string.join(" ")
   }
-
-  "transform: " <> content
 }

--- a/sketch/src/sketch/transform.gleam
+++ b/sketch/src/sketch/transform.gleam
@@ -77,7 +77,7 @@ pub fn scale_y(y: Float) {
 }
 
 pub fn rotate(value: Angle) {
-	Rotate(value)
+  Rotate(value)
 }
 
 pub fn skew_x(x: Angle) {
@@ -89,7 +89,7 @@ pub fn skew_y(x: Angle) {
 }
 
 pub fn none() {
-	None
+  None
 }
 
 pub fn list(values: List(TransformFunction)) {

--- a/sketch/src/sketch/transform.gleam
+++ b/sketch/src/sketch/transform.gleam
@@ -46,6 +46,7 @@ pub fn translate2(x: Size, y: Size) {
   Translate(x, y)
 }
 
+/// translate(x) is translate2(x, size.percent(0))
 pub fn translate(x: Size) {
   translate2(x, size.percent(0))
 }
@@ -62,8 +63,9 @@ pub fn scale2(x: Float, y: Float) {
   Scale(x, y)
 }
 
-pub fn scale(x: Float, ) {
-  Scale(x, x)
+/// scale(x) is scale2(x, x)
+pub fn scale(x: Float) {
+  scale2(x, x)
 }
 
 pub fn scale_x(x: Float) {

--- a/sketch/src/sketch/transform.gleam
+++ b/sketch/src/sketch/transform.gleam
@@ -74,6 +74,10 @@ pub fn scale_y(y: Float) {
   ScaleY(y)
 }
 
+pub fn rotate(value: Angle) {
+	Rotate(value)
+}
+
 pub fn skew_x(x: Angle) {
   SkewX(x)
 }

--- a/sketch/src/sketch/transform.gleam
+++ b/sketch/src/sketch/transform.gleam
@@ -1,0 +1,104 @@
+import gleam/float
+import gleam/list
+import gleam/option.{type Option}
+import gleam/string
+import sketch/angle.{type Angle}
+import sketch/size.{type Size}
+
+pub opaque type Transform {
+  None
+  TransformList(List(TransformFunction))
+}
+
+pub opaque type TransformFunction {
+  Translate(Size, Option(Size))
+  TranslateX(Size)
+  TranslateY(Size)
+  Scale(Float, Option(Float))
+  ScaleX(Float)
+  ScaleY(Float)
+  Rotate(Angle)
+  Skew(Angle, Option(Angle))
+  SkewX(Angle)
+  SkewY(Angle)
+}
+
+fn transform_function_to_string(value: TransformFunction) {
+  case value {
+    Translate(x, option.None) ->
+      "translate("
+      <> string.join([size.to_string(x), size.to_string(x)], ",")
+      <> ")"
+    Translate(x, option.Some(y)) ->
+      "translate("
+      <> string.join([size.to_string(x), size.to_string(y)], ",")
+      <> ")"
+    TranslateX(x) -> "translateX(" <> size.to_string(x) <> ")"
+    TranslateY(y) -> "translateY(" <> size.to_string(y) <> ")"
+    Scale(x, option.None) ->
+      "scale("
+      <> string.join([float.to_string(x), float.to_string(x)], ",")
+      <> ")"
+    Scale(x, option.Some(y)) ->
+      "scale("
+      <> string.join([float.to_string(x), float.to_string(y)], ",")
+      <> ")"
+    ScaleX(x) -> "scaleX(" <> float.to_string(x) <> ")"
+    ScaleY(y) -> "scaleY(" <> float.to_string(y) <> ")"
+    Rotate(ang) -> "rotate(" <> angle.to_string(ang) <> ")"
+    Skew(x, option.None) ->
+      "translate(" <> string.join([angle.to_string(x), "0"], ",") <> ")"
+    Skew(x, option.Some(y)) ->
+      "translate("
+      <> string.join([angle.to_string(x), angle.to_string(y)], ",")
+      <> ")"
+    SkewX(x) -> "skewX(" <> angle.to_string(x) <> ")"
+    SkewY(y) -> "skewY(" <> angle.to_string(y) <> ")"
+  }
+}
+
+pub fn translate(x: Size, y: Option(Size)) {
+  Translate(x, y)
+}
+
+pub fn translate_x(x: Size) {
+  TranslateX(x)
+}
+
+pub fn translate_y(y: Size) {
+  TranslateY(y)
+}
+
+pub fn scale(x: Float, y: Option(Float)) {
+  Scale(x, y)
+}
+
+pub fn scale_x(x: Float) {
+  ScaleX(x)
+}
+
+pub fn scale_y(y: Float) {
+  ScaleY(y)
+}
+
+pub fn skew(x: Angle, y: Option(Angle)) {
+  Skew(x, y)
+}
+
+pub fn skew_x(x: Angle) {
+  SkewX(x)
+}
+
+pub fn skew_y(x: Angle) {
+  SkewY(x)
+}
+
+pub fn to_string(value: Transform) {
+  let content = case value {
+    None -> "none"
+    TransformList(transform_list) ->
+      list.map(transform_list, transform_function_to_string) |> string.join(" ")
+  }
+
+  "transform: " <> content
+}

--- a/sketch/test/transform_test.gleam
+++ b/sketch/test/transform_test.gleam
@@ -6,67 +6,67 @@ import sketch/transform
 pub fn translate_test() {
   [transform.translate(size.px(10))]
   |> transform.to_string
-  |> should.equal("transform: translate(10.0px,0.0%)")
+  |> should.equal("translate(10.0px,0.0%)")
 }
 
 pub fn translate2_test() {
   [transform.translate2(size.px(10), size.rem(3.0))]
   |> transform.to_string
-  |> should.equal("transform: translate(10.0px,3.0rem)")
+  |> should.equal("translate(10.0px,3.0rem)")
 }
 
 pub fn translate_x() {
   [transform.translate_x(size.px(10))]
   |> transform.to_string
-  |> should.equal("transform: translateX(10px)")
+  |> should.equal("translateX(10px)")
 }
 
 pub fn translate_y() {
   [transform.translate_y(size.px(10))]
   |> transform.to_string
-  |> should.equal("transform: translateY(10px)")
+  |> should.equal("translateY(10px)")
 }
 
 pub fn scale2_test() {
   [transform.scale2(10.0, 10.0)]
   |> transform.to_string
-  |> should.equal("transform: scale(10.0,10.0)")
+  |> should.equal("scale(10.0,10.0)")
 }
 
 pub fn scale_test() {
   [transform.scale(10.0)]
   |> transform.to_string
-  |> should.equal("transform: scale(10.0,10.0)")
+  |> should.equal("scale(10.0,10.0)")
 }
 
 pub fn scale_x_test() {
   [transform.scale_x(10.0)]
   |> transform.to_string
-  |> should.equal("transform: scaleX(10.0)")
+  |> should.equal("scaleX(10.0)")
 }
 
 pub fn scale_y_test() {
   [transform.scale_y(10.0)]
   |> transform.to_string
-  |> should.equal("transform: scaleY(10.0)")
+  |> should.equal("scaleY(10.0)")
 }
 
 pub fn rotate_test() {
   [transform.rotate(angle.rad(2.0))]
   |> transform.to_string
-  |> should.equal("transform: rotate(2.0rad)")
+  |> should.equal("rotate(2.0rad)")
 }
 
 pub fn skew_x() {
   [transform.skew_x(angle.rad(2.0))]
   |> transform.to_string
-  |> should.equal("transform: skewX(2.0rad)")
+  |> should.equal("skewX(2.0rad)")
 }
 
 pub fn skew_y() {
   [transform.skew_y(angle.rad(2.0))]
   |> transform.to_string
-  |> should.equal("transform: skewY(2.0rad)")
+  |> should.equal("skewY(2.0rad)")
 }
 
 pub fn translate_equiv_test() {
@@ -87,5 +87,5 @@ pub fn scale_equiv_test() {
 
 pub fn transform_none_test() {
   transform.to_string([])
-  |> should.equal("transform: none")
+  |> should.equal("none")
 }

--- a/sketch/test/transform_test.gleam
+++ b/sketch/test/transform_test.gleam
@@ -1,0 +1,105 @@
+import gleeunit/should
+import sketch/angle
+import sketch/size
+import sketch/transform
+
+pub fn translate_test() {
+  [transform.translate(size.px(10))]
+  |> transform.list
+  |> transform.to_string
+  |> should.equal("transform: translate(10.0px,0.0%)")
+}
+
+pub fn translate2_test() {
+  [transform.translate2(size.px(10), size.rem(3.0))]
+  |> transform.list
+  |> transform.to_string
+  |> should.equal("transform: translate(10.0px,3.0rem)")
+}
+
+pub fn translate_x() {
+  [transform.translate_x(size.px(10))]
+  |> transform.list
+  |> transform.to_string
+  |> should.equal("transform: translateX(10px)")
+}
+
+pub fn translate_y() {
+  [transform.translate_y(size.px(10))]
+  |> transform.list
+  |> transform.to_string
+  |> should.equal("transform: translateY(10px)")
+}
+
+pub fn scale2_test() {
+  [transform.scale2(10.0, 10.0)]
+  |> transform.list
+  |> transform.to_string
+  |> should.equal("transform: scale(10.0,10.0)")
+}
+
+pub fn scale_test() {
+  [transform.scale(10.0)]
+  |> transform.list
+  |> transform.to_string
+  |> should.equal("transform: scale(10.0,10.0)")
+}
+
+pub fn scale_x_test() {
+  [transform.scale_x(10.0)]
+  |> transform.list
+  |> transform.to_string
+  |> should.equal("transform: scaleX(10.0)")
+}
+
+pub fn scale_y_test() {
+  [transform.scale_y(10.0)]
+  |> transform.list
+  |> transform.to_string
+  |> should.equal("transform: scaleY(10.0)")
+}
+
+pub fn rotate_test() {
+  [transform.rotate(angle.rad(2.0))]
+  |> transform.list
+  |> transform.to_string
+  |> should.equal("transform: rotate(2.0rad)")
+}
+
+pub fn skew_x() {
+  [transform.skew_x(angle.rad(2.0))]
+  |> transform.list
+  |> transform.to_string
+  |> should.equal("transform: skewX(2.0rad)")
+}
+
+pub fn skew_y() {
+  [transform.skew_y(angle.rad(2.0))]
+  |> transform.list
+  |> transform.to_string
+  |> should.equal("transform: skewY(2.0rad)")
+}
+
+pub fn translate_equiv_test() {
+  let current =
+    [transform.translate(size.px(10))] |> transform.list |> transform.to_string
+  let expected =
+    [transform.translate2(size.px(10), size.percent(0))]
+    |> transform.list
+    |> transform.to_string
+
+  should.equal(current, expected)
+}
+
+pub fn scale_equiv_test() {
+  let current = [transform.scale(10.0)] |> transform.list |> transform.to_string
+  let expected =
+    [transform.scale2(10.0, 10.0)] |> transform.list |> transform.to_string
+
+  should.equal(current, expected)
+}
+
+pub fn transform_none_test() {
+  transform.to_string(transform.none())
+  |> should.equal("transform: none")
+}

--- a/sketch/test/transform_test.gleam
+++ b/sketch/test/transform_test.gleam
@@ -5,101 +5,87 @@ import sketch/transform
 
 pub fn translate_test() {
   [transform.translate(size.px(10))]
-  |> transform.list
   |> transform.to_string
   |> should.equal("transform: translate(10.0px,0.0%)")
 }
 
 pub fn translate2_test() {
   [transform.translate2(size.px(10), size.rem(3.0))]
-  |> transform.list
   |> transform.to_string
   |> should.equal("transform: translate(10.0px,3.0rem)")
 }
 
 pub fn translate_x() {
   [transform.translate_x(size.px(10))]
-  |> transform.list
   |> transform.to_string
   |> should.equal("transform: translateX(10px)")
 }
 
 pub fn translate_y() {
   [transform.translate_y(size.px(10))]
-  |> transform.list
   |> transform.to_string
   |> should.equal("transform: translateY(10px)")
 }
 
 pub fn scale2_test() {
   [transform.scale2(10.0, 10.0)]
-  |> transform.list
   |> transform.to_string
   |> should.equal("transform: scale(10.0,10.0)")
 }
 
 pub fn scale_test() {
   [transform.scale(10.0)]
-  |> transform.list
   |> transform.to_string
   |> should.equal("transform: scale(10.0,10.0)")
 }
 
 pub fn scale_x_test() {
   [transform.scale_x(10.0)]
-  |> transform.list
   |> transform.to_string
   |> should.equal("transform: scaleX(10.0)")
 }
 
 pub fn scale_y_test() {
   [transform.scale_y(10.0)]
-  |> transform.list
   |> transform.to_string
   |> should.equal("transform: scaleY(10.0)")
 }
 
 pub fn rotate_test() {
   [transform.rotate(angle.rad(2.0))]
-  |> transform.list
   |> transform.to_string
   |> should.equal("transform: rotate(2.0rad)")
 }
 
 pub fn skew_x() {
   [transform.skew_x(angle.rad(2.0))]
-  |> transform.list
   |> transform.to_string
   |> should.equal("transform: skewX(2.0rad)")
 }
 
 pub fn skew_y() {
   [transform.skew_y(angle.rad(2.0))]
-  |> transform.list
   |> transform.to_string
   |> should.equal("transform: skewY(2.0rad)")
 }
 
 pub fn translate_equiv_test() {
-  let current =
-    [transform.translate(size.px(10))] |> transform.list |> transform.to_string
+  let current = [transform.translate(size.px(10))] |> transform.to_string
   let expected =
     [transform.translate2(size.px(10), size.percent(0))]
-    |> transform.list
     |> transform.to_string
 
   should.equal(current, expected)
 }
 
 pub fn scale_equiv_test() {
-  let current = [transform.scale(10.0)] |> transform.list |> transform.to_string
-  let expected =
-    [transform.scale2(10.0, 10.0)] |> transform.list |> transform.to_string
+  let current = [transform.scale(10.0)] |> transform.to_string
+  let expected = [transform.scale2(10.0, 10.0)] |> transform.to_string
 
   should.equal(current, expected)
 }
 
 pub fn transform_none_test() {
-  transform.to_string(transform.none())
+  transform.to_string([])
   |> should.equal("transform: none")
 }


### PR DESCRIPTION
Here is a suggestion of the transform API, it was implemented based on [css-transform-1 spec](https://www.w3.org/TR/css-transforms-1) but i noticed that there is a newer version [css-transform-2 spec](https://drafts.csswg.org/css-transforms-2/) that has some additions/changes.

From the first version of the spec, only the `matrix()` function is not implemented.

I dispose myself to update the current implementation to `css-transform-2` after review of the API status, but would like to know if it is preferable to do it in this PR or create a new one.