### PR TITLE
Account for renaming of the `sketch_lustre_experimental` package, as well as API differences

### DIFF
--- a/sketch_lustre_experimental/package.json
+++ b/sketch_lustre_experimental/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sketch_magic",
+  "name": "sketch_lustre_experimental",
   "packageManager": "yarn@4.3.1",
   "scripts": {
     "clean": "gleam clean"

--- a/sketch_lustre_experimental/src/global.ffi.mjs
+++ b/sketch_lustre_experimental/src/global.ffi.mjs
@@ -4,7 +4,7 @@ let _stylesheet = null
 
 export function setStyleSheet(stylesheet) {
   _stylesheet = stylesheet
-  return stylesheet
+  return new gleam.Ok(stylesheet)
 }
 
 export function getStyleSheet() {

--- a/sketch_lustre_experimental/src/sketch/lustre/experimental/internals/global.gleam
+++ b/sketch_lustre_experimental/src/sketch/lustre/experimental/internals/global.gleam
@@ -1,13 +1,13 @@
 import sketch
 
-@external(javascript, "../../../../sketch_magic.ffi.mjs", "setStyleSheet")
+@external(javascript, "../../../../global.ffi.mjs", "setStyleSheet")
 pub fn set_stylesheet(
   stylesheet: sketch.StyleSheet,
 ) -> Result(sketch.StyleSheet, Nil) {
   Ok(stylesheet)
 }
 
-@external(javascript, "../../../../sketch_magic.ffi.mjs", "getStyleSheet")
+@external(javascript, "../../../../global.ffi.mjs", "getStyleSheet")
 pub fn get_stylesheet() -> Result(sketch.StyleSheet, Nil) {
   Error(Nil)
 }


### PR DESCRIPTION
`global.ffi.mjs` seems to have been called `sketch_magic.ffi.mjs` before, named after the previous package name. The current API also expects `set_stylesheet` to return a result.